### PR TITLE
:adhesive_bandage: dropSchema 옵션 제거, endpoint 동작 확인

### DIFF
--- a/Server/ormconfig.js
+++ b/Server/ormconfig.js
@@ -12,5 +12,5 @@ module.exports = {
   factories: ['dist/factories/**/*.js'], // factory를 위한 디렉토리
   logging: false,
   synchronize: true,
-  dropSchema: true, // each time connection being established, DB will be refreshed.
+  // dropSchema: true, // each time connection being established, DB will be refreshed.
 };

--- a/Server/src/controllers/exercise.ts
+++ b/Server/src/controllers/exercise.ts
@@ -4,7 +4,7 @@ import Exercise from '../entity/Exercise.entity';
 
 // * 운동 보기
 export const getExercise = async (req: Request, res: Response): Promise<void> => {
-  console.log(await getConnection().getRepository(Exercise).find());
-  res.status(200).send('hi');
+  const exercises: Exercise[] = await getConnection().getRepository(Exercise).find();
+  res.status(200).send(exercises);
   return;
 };


### PR DESCRIPTION
dropSchema는 서버가 재 실행될 때마다 모든 데이터를 지운다. 따라서 엔드포인트 확인을 위해서는 옵션을 끌 필요가 있다.